### PR TITLE
Add stop button to interrupt model

### DIFF
--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -220,10 +220,14 @@
                         </select>
                     </div>
 
-                     <!-- Send Button (doesn't shrink) -->
-                     <button class="btn btn-primary flex-shrink-0" id="send-btn" title="Send Message">
-                          <i class="bi bi-send-fill"></i> <span class="d-none d-sm-inline">Send</span>
-                     </button>
+                    <!-- Send Button (doesn't shrink) -->
+                    <button class="btn btn-primary flex-shrink-0" id="send-btn" title="Send Message">
+                         <i class="bi bi-send-fill"></i> <span class="d-none d-sm-inline">Send</span>
+                    </button>
+                    <!-- Stop Button (initially hidden) -->
+                    <button class="btn btn-outline-danger flex-shrink-0" id="stop-btn" title="Stop generating" style="display: none;">
+                         <i class="bi bi-stop-fill"></i> <span class="d-none d-sm-inline">Stop</span>
+                    </button>
                 </div>
             </div>
         </div> 


### PR DESCRIPTION
Add a Stop button to the chat UI to allow users to cancel in-progress model response generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd5a1911-273f-4e92-be95-c0fcc45a0a4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd5a1911-273f-4e92-be95-c0fcc45a0a4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

